### PR TITLE
Add continuous integration GitHub action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,45 @@
+---
+name: CI
+
+on:
+  push:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "3.8"
+          cache: "pip"
+          cache-dependency-path: requirements.*.txt
+      - uses: extractions/setup-just@v1
+      - name: Check formatting, linting, and import sorting
+        run: just check
+
+  test:
+    needs: [check]
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "3.8"
+          cache: "pip"
+          cache-dependency-path: requirements.*.txt
+      - uses: extractions/setup-just@v1
+      - name: Run tests
+        # env: # Add environment variables required for tests
+        run: |
+          just test
+
+  lint-dockerfile:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: hadolint/hadolint-action@v1.5.0
+        with:
+          failure-threshold: error

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,11 +35,3 @@ jobs:
         # env: # Add environment variables required for tests
         run: |
           just test
-
-  lint-dockerfile:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: hadolint/hadolint-action@v1.5.0
-        with:
-          failure-threshold: error

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,8 +31,3 @@ repos:
     - id: check-toml
     - id: check-yaml
     - id: detect-private-key
-
-  - repo: https://github.com/stratasan/hadolint-pre-commit
-    rev: cdefcb0
-    hooks:
-    - id: hadolint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,29 +5,29 @@ repos:
   - repo: https://github.com/psf/black
     rev: 22.1.0
     hooks:
-    - id: black
+      - id: black
 
   - repo: https://github.com/pycqa/flake8
     rev: 4.0.1
     hooks:
-    - id: flake8
-      additional_dependencies:
-      - "flake8-builtins"
-      - "flake8-no-pep420"
+      - id: flake8
+        additional_dependencies:
+          - "flake8-builtins"
+          - "flake8-no-pep420"
 
   - repo: https://github.com/pycqa/isort
     rev: 5.10.1
     hooks:
-    - id: isort
+      - id: isort
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.1.0
     hooks:
-    - id: trailing-whitespace
-    - id: end-of-file-fixer
-    - id: debug-statements
-    - id: check-ast
-    - id: check-json
-    - id: check-toml
-    - id: check-yaml
-    - id: detect-private-key
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: debug-statements
+      - id: check-ast
+      - id: check-json
+      - id: check-toml
+      - id: check-yaml
+      - id: detect-private-key

--- a/deciles_chart/core.py
+++ b/deciles_chart/core.py
@@ -72,6 +72,12 @@ def drop_zero_denominator_rows(measure_table: pandas.DataFrame) -> pandas.DataFr
 def get_deciles_table(measure_table: pandas.DataFrame) -> pandas.DataFrame:
     by = ["date"] + measure_table.attrs["group_by"][1:]
     deciles_table = measure_table.groupby(by)["value"].quantile(DECILES).reset_index()
+    # Previously, it wasn't necessary to rename "level_1", which is created by the call
+    # to .quantile, to "deciles" because this method used the name of DECILES (i.e.
+    # Series.name). However, it now is, which may be a regression in Pandas. When we
+    # downgrade Pandas (a prod dependency) to match opensafely-core/python-docker, we
+    # should revisit.
+    deciles_table = deciles_table.rename(columns={"level_1": "deciles"})
     # `measure_table.attrs` isn't persisted.
     deciles_table.attrs = measure_table.attrs.copy()
     return deciles_table


### PR DESCRIPTION
This follows #2, which @ccunningham101 and @milanwiedemann 👀 last week. It adds a CI (Continuous Integration) GitHub action that runs `just check` and then `just test` on a push to any branch on GitHub. Just before we do, we fix a bug to ensure that this action gives us a ✅. We also remove hadolint and fix some YAML formatting.