### PR TITLE
Remove auto-merge-dependabot workflow

### DIFF
--- a/.github/workflows/auto-merge-dependabot-prs.yml
+++ b/.github/workflows/auto-merge-dependabot-prs.yml
@@ -1,9 +1,0 @@
-name: Auto merge Dependabot PRs
-
-on: pull_request
-
-jobs:
-  auto-merge-dependabot-prs:
-    uses: opensafely-core/.github/.github/workflows/auto-merge-dependabot-prs.yml@main
-    secrets:
-      token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The upstream workflow was removed:

https://github.com/opensafely-core/.github/commit/9e65bb96e26702743b6c6b90f9c3cdb53da61983